### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -26,11 +26,11 @@ set zephyr_GIT_DIVERGED "$set_cyan ⇡$set_magenta⇣$set_normal"
 # git
 
 function _is_git_dirty
-    echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+    echo (command git status -s --ignore-submodules=dirty 2>/dev/null)
 end
 
 function _git_branch_name
-    echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+    echo (command git symbolic-ref HEAD 2>/dev/null | sed -e 's|^refs/heads/||')
 end
 
 # node
@@ -50,7 +50,7 @@ function fish_prompt
         set node_info " $zephyr_NODE_SYMBOL$set_green $node_version$set_normal"
     end
 
-    set -l push_or_pull (command git status --porcelain ^/dev/null -b)
+    set -l push_or_pull (command git status --porcelain 2>/dev/null -b)
     set -l is_behind
     set -l is_ahead
     set -l git_on 'on '


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
